### PR TITLE
Start, previous, next and end buttons in transport bar

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -1,1 +1,1 @@
-{"lastCommitDate": "2024/12/11"}
+{"lastCommitDate": "2024/12/16"}

--- a/src/client/assets/svg/ff.svg
+++ b/src/client/assets/svg/ff.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+
+<svg
+   width="1171.9325"
+   height="803.61365"
+   viewBox="0 0 35.157975 24.108409"
+   fill="none"
+   version="1.1"
+   id="svg9"
+   sodipodi:docname="ff.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs13" />
+  <sodipodi:namedview
+     id="namedview11"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="0.1767767"
+     inkscape:cx="376.18081"
+     inkscape:cy="158.39192"
+     inkscape:window-width="1366"
+     inkscape:window-height="701"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg9"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <g
+     id="SVGRepo_bgCarrier"
+     stroke-width="0"
+     transform="translate(-0.1563301,-0.0740744)" />
+  <g
+     id="SVGRepo_tracerCarrier"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     transform="translate(-0.1563301,-0.0740744)" />
+  <g
+     id="SVGRepo_iconCarrier"
+     transform="matrix(1.9532209,0,0,1.9532209,-5.8596627,-11.719325)">
+    <path
+       d="M 11.7429,12.1714 3,18.3429 V 6 Z"
+       fill="#02a7f0"
+       id="path4" />
+    <path
+       d="M 12.2571,18.3429 21,12.1714 12.2571,6 Z"
+       fill="#02a7f0"
+       id="path6" />
+  </g>
+</svg>

--- a/src/client/assets/svg/start.svg
+++ b/src/client/assets/svg/start.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+
+<svg
+   fill="#000000"
+   width="800px"
+   height="800px"
+   viewBox="-2 0 32 32"
+   preserveAspectRatio="xMidYMid"
+   version="1.1"
+   id="svg19933"
+   sodipodi:docname="start-svgrepo-com.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs19937" />
+  <sodipodi:namedview
+     id="namedview19935"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="0.328125"
+     inkscape:cx="830.47619"
+     inkscape:cy="505.90476"
+     inkscape:window-width="1366"
+     inkscape:window-height="701"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg19933" />
+  <path
+     d="M26.530,31.994 C26.222,31.994 25.915,31.903 25.619,31.722 L2.000,17.205 L2.000,31.000 C2.000,31.553 1.552,32.000 1.000,32.000 C0.448,32.000 -0.000,31.553 -0.000,31.000 L-0.000,1.006 C-0.000,0.453 0.448,0.006 1.000,0.006 C1.552,0.006 2.000,0.453 2.000,1.006 L2.000,13.855 L25.628,0.248 C25.917,0.083 26.211,-0.000 26.507,-0.000 C27.372,-0.000 28.000,0.689 28.000,1.639 L28.000,30.367 C28.000,31.435 27.260,31.994 26.530,31.994 ZM3.097,15.531 L26.000,29.608 L26.000,2.341 L3.097,15.531 Z"
+     id="path19931"
+     style="fill:#02a7f0;fill-opacity:1" />
+  <path
+     style="fill:#02a7f0;stroke:#02a7f0;stroke-width:0.284;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 3.097,15.531 26,2.341 v 27.267 z"
+     id="path20065" />
+</svg>

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -86,7 +86,9 @@
       "icons": "Icons",
       "piano": "Piano",
       "volume": "Volume",
-      "sliders": "Sliders"
+      "sliders": "Sliders",
+      "start": "Start",
+      "ff": "Fast forward"
     }
   },
   "guide": {

--- a/src/client/locales/fr.json
+++ b/src/client/locales/fr.json
@@ -86,7 +86,9 @@
       "icons": "Icônes",
       "piano": "Piano",
       "volume": "Volume",
-      "sliders": "Sliders"
+      "sliders": "Sliders",
+      "start": "Début",
+      "ff": "Avance rapide"
     }
   },
   "guide": {

--- a/src/client/pages/Credits.vue
+++ b/src/client/pages/Credits.vue
@@ -50,6 +50,20 @@
           {{ $t('credits.icons.sliders') }}
         </a> :
         <strong>DailyPM Studio, Flaticon</strong>
+
+        <br/>
+
+        <a href="https://www.svgrepo.com/svg/509259/start" title="begin icon">
+          {{ $t('credits.icons.start') }}
+        </a> :
+        <strong>Orchid, SvgRepo</strong>
+
+        <br/>
+        
+        <a href="https://www.svgrepo.com/svg/439779/fast-forward-fill" title="fast-forward icon">
+          {{ $t('credits.icons.ff') }}
+        </a> :
+        <strong>emblemicons, SvgRepo</strong>
       </p>
     </div>
 


### PR DESCRIPTION
These are SVG icons, thankfully. There is nothing much to say about the  implementation per se, however, the CSS, as usual, is rather finicky,  mostly due to the fact that the (now rather antiquated) pure-CSS play  button appears to be closer to the fast forward icon, requiring rather  awkward adjustments. However, the end result is still very palatable.